### PR TITLE
* feat : 페이지 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     //타임리프
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
     // https://mvnrepository.com/artifact/io.findify/s3mock
     testImplementation group: 'io.findify', name: 's3mock_2.13', version: '0.2.6'
+
 
 }
 

--- a/src/main/java/byuntil/backend/admin/config/SecurityConfig.java
+++ b/src/main/java/byuntil/backend/admin/config/SecurityConfig.java
@@ -16,24 +16,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     PasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();
     }
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        //USER라는 권한 부여
-        //user1이라는 id, 인코딩된 pw를 password에 인자로 넘기기
-        auth.inMemoryAuthentication().withUser("user1")
-                .password("$2a$10$qjTbkhjVLWuZEwJuBHox1.iKBR5Sf6xG.NkGQbV5cffc6ecNxNuUi")
-                .roles("USER");
-    }
+
     @Override
     protected void configure(HttpSecurity http)throws Exception{
-        //아래의 antMatchers에는 resources/templates하위가 와야하는건가
+        //아래의 antMatchers에는 resources/templates하위가 와야하는건가 -> 아님
         http.authorizeRequests()
                 .antMatchers("/sample/all").permitAll()
-                .antMatchers("/sample/member").hasRole("USER");
-        // /sample/all 페이지는
-        // permitAll : 모든 사용자에게 허락
-        // /sample/member페이지는
-        // USER권한을 가진 사용자에게만 허락되는 페이지이다
+                .antMatchers("/sample/member").hasRole("ADMIN");
         http.formLogin();//인가/인증에 문제시 로그인 화면을 보여준다
         http.csrf().disable();//csrf 공격을 막기 위한 csrf토큰 안보이게 처리
         http.logout();

--- a/src/main/java/byuntil/backend/admin/controlller/SampleController.java
+++ b/src/main/java/byuntil/backend/admin/controlller/SampleController.java
@@ -1,6 +1,8 @@
 package byuntil.backend.admin.controlller;
 
+import byuntil.backend.admin.domain.dto.AdminDto;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,8 +18,8 @@ public class SampleController {
         return "akk";
     }
     @GetMapping("/member")
-    public String exMember(){
-        log.info("exMember");
+    public String exMember(@AuthenticationPrincipal AdminDto user){
+        log.info(user.getUsername());
         return "member";
     }
     @GetMapping("/admin")

--- a/src/main/java/byuntil/backend/admin/domain/Admin.java
+++ b/src/main/java/byuntil/backend/admin/domain/Admin.java
@@ -1,11 +1,20 @@
 package byuntil.backend.admin.domain;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.catalina.User;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Admin {
     @Id
     @GeneratedValue
@@ -17,4 +26,13 @@ public class Admin {
 
     @Column(nullable = false)
     private String loginPw;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @Builder.Default
+    private Set<UserRole> roleSet = new HashSet<>();
+
+    public void addUserRole(UserRole role){
+        roleSet.add(role);
+    }
+
 }

--- a/src/main/java/byuntil/backend/admin/domain/UserRole.java
+++ b/src/main/java/byuntil/backend/admin/domain/UserRole.java
@@ -1,0 +1,5 @@
+package byuntil.backend.admin.domain;
+
+public enum UserRole {
+    ADMIN
+}

--- a/src/main/java/byuntil/backend/admin/domain/dto/AdminDto.java
+++ b/src/main/java/byuntil/backend/admin/domain/dto/AdminDto.java
@@ -1,0 +1,22 @@
+package byuntil.backend.admin.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Slf4j
+@Getter
+@Setter
+@ToString
+public class AdminDto extends User {
+    private String loginId;
+    public AdminDto(String loginId, String loginPw, Collection<? extends GrantedAuthority> authorities){
+        super(loginId, loginPw, authorities);
+    }
+    //pw는 부모의 pw를 사용하기때문에 넣지 않았다
+}

--- a/src/main/java/byuntil/backend/admin/repository/AdminRepository.java
+++ b/src/main/java/byuntil/backend/admin/repository/AdminRepository.java
@@ -1,0 +1,15 @@
+package byuntil.backend.admin.repository;
+
+import byuntil.backend.admin.domain.Admin;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+    @EntityGraph(attributePaths = {"roleSet"}, type = EntityGraph.EntityGraphType.LOAD)
+    @Query("select m from Admin m where m.loginId = :loginId")
+    Optional<Admin> findByLoginId(@Param("loginId") String loginId);
+}

--- a/src/main/java/byuntil/backend/admin/service/UserDetailService.java
+++ b/src/main/java/byuntil/backend/admin/service/UserDetailService.java
@@ -1,0 +1,35 @@
+package byuntil.backend.admin.service;
+
+import byuntil.backend.admin.domain.Admin;
+import byuntil.backend.admin.domain.dto.AdminDto;
+import byuntil.backend.admin.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserDetailService implements UserDetailsService {
+    private final AdminRepository adminRepository;
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        log.info("username : " + username);
+
+        Optional<Admin> result = adminRepository.findByLoginId(username);
+        if(!result.isPresent()){
+            throw new UsernameNotFoundException("Check Id");
+        }
+        Admin admin = result.get();
+        AdminDto dto = new AdminDto(admin.getLoginId(), admin.getLoginPw(), admin.getRoleSet().stream()
+                .map(userRole -> new SimpleGrantedAuthority("ROLE_" + userRole.name())).collect(Collectors.toSet()));
+        return dto;
+    }
+}

--- a/src/test/java/byuntil/backend/admin/MemberTests.java
+++ b/src/test/java/byuntil/backend/admin/MemberTests.java
@@ -1,0 +1,56 @@
+package byuntil.backend.admin;
+
+import byuntil.backend.admin.domain.Admin;
+import byuntil.backend.admin.domain.UserRole;
+import byuntil.backend.admin.repository.AdminRepository;
+import byuntil.backend.member.domain.entity.member.Member;
+import byuntil.backend.member.domain.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+@SpringBootTest
+public class MemberTests {
+    @Autowired
+    private AdminRepository adminRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    public void 권한확인(){
+        //given
+        Optional<Admin> result = adminRepository.findByLoginId("user2");
+        //when
+        Set<UserRole> roles = result.get().getRoleSet();
+        //then
+        Assertions.assertThat(roles.contains(UserRole.ADMIN));
+    }
+    @Test
+    public void testRead(){
+        //given
+        Optional<Admin> result = adminRepository.findByLoginId("user2");
+        //when
+        Admin admin = result.get();
+        //then
+        Assertions.assertThat(admin.getLoginId()).isEqualTo("user2");
+    }
+    @Test
+    public void insertDummies(){
+        //10개의 user생성
+        //given
+        IntStream.rangeClosed(1,10).forEach(i -> {
+            Admin admin = Admin.builder().loginId("user" + i).loginPw(passwordEncoder.encode("111")).build();
+            admin.addUserRole(UserRole.ADMIN);
+            adminRepository.save(admin);
+        });
+        //when
+        //then
+        Assertions.assertThat(adminRepository.findAll().size()).isEqualTo(10);
+    }
+}


### PR DESCRIPTION
## * feat : 페이지 구현
sample/member - DB에 저장된 계정으로 로그인을 해야만(ADMIN권한이 있는 계정만) 접근 가능
sample/all - 모든 user가 접근 가능



1) userRole 생성하고 Admin entity에 role에 대한 멤버변수 추가
나중에 userRole이 여러개 생길 수도있으니 일단 enum으로 구현
2) auth를 인자로 받는 configure 삭제
 그거 대신 디비에 저장해둔 user1~user10으로 test진행
3) controller-member 메서드를 login의 결과로 return되는 dto를 인자로 받는 함수로 변경
4) adminRepository에 loginId로 해당하는 Admin계정을 찾는 메서드 추가
5) userDetailService 작성 : userDetailsService를 상속받는 서비스로 이 서비스에서 return 된 값이 @AuthenticationPrincipal의 인자로 들어간다
